### PR TITLE
Add missing config file update for outputDir in section 2.2.2

### DIFF
--- a/docs/en/docs/hello_nextflow/06_hello_config.md
+++ b/docs/en/docs/hello_nextflow/06_hello_config.md
@@ -745,7 +745,27 @@ Let's put that back, and also put the files in a `params.batch` subdirectory.
 
     Including `params.batch` in the output block `path`, instead of the `outputDir` config, means that it won't be overwritten with `-output-dir` on the CLI.
 
-Make the following changes in the workflow file:
+First, update the config file to remove `${params.batch}` from `outputDir` (since we're moving it to the path declarations):
+
+=== "After"
+
+    ```groovy title="nextflow.config" linenums="12"
+    /*
+    * Output settings
+    */
+    outputDir = "config_results/"
+    ```
+
+=== "Before"
+
+    ```groovy title="nextflow.config" linenums="12"
+    /*
+    * Output settings
+    */
+    outputDir = "config_results/${params.batch}"
+    ```
+
+Then, make the following changes in the workflow file:
 
 === "After"
 


### PR DESCRIPTION
## Summary
- Adds the missing config file Before/After block in section 2.2.2 to show that `outputDir` should be updated when moving `${params.batch}` to the path declarations

When the tutorial moves `${params.batch}` from the config's `outputDir` to the workflow's path declarations, the config file needs to be updated accordingly. This was implied but not explicitly shown.

## Context
Found during tutorial walkthrough testing with `NXF_SYNTAX_PARSER=v2`.

🤖 Generated with [Claude Code](https://claude.ai/code)